### PR TITLE
Update examples to Bevy 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ keywords = ["gamedev", "bevy", "shaders", "graphics"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { version = "0.14", default-features=false, features = [ "bevy_render", "bevy_asset", "bevy_pbr", "bevy_sprite" ] }
+bevy = { version = "0.15", default-features=false, features = [ "bevy_render", "bevy_asset", "bevy_pbr", "bevy_sprite" ] }
 
 [dev-dependencies]
-bevy = "0.14"
+bevy = "0.15.0-rc.3"
 
 [badges.maintenance]
 status = "actively-developed"

--- a/examples/quad.rs
+++ b/examples/quad.rs
@@ -1,6 +1,6 @@
 //! Shows the terminal material rendered on a quad.
 
-use bevy::{prelude::*, sprite::MaterialMesh2dBundle};
+use bevy::prelude::*;
 use bevy_terminal_shader::{TerminalMaterial, TerminalShaderPlugin};
 
 fn main() {
@@ -16,14 +16,10 @@ fn setup(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<TerminalMaterial>>,
 ) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d::default());
 
-    commands.spawn(MaterialMesh2dBundle {
-        mesh: meshes
-            // .add(shape::Quad::new(Vec2::new(1300., 800.)).into())
-            .add(bevy::math::primitives::Rectangle::new(1300., 800.))
-            .into(),
-        material: materials.add(TerminalMaterial::green()),
-        ..default()
-    });
+    commands.spawn((
+        Mesh2d(meshes.add(Rectangle::new(1300., 800.).mesh())),
+        MeshMaterial2d(materials.add(TerminalMaterial::green())),
+    ));
 }


### PR DESCRIPTION
- Updated the quad and cube examples to use the new `Mesh3d` and `MaterialMesh3d` components.

The cube example crashes with a shader error.

```sh
❯ cargo run --example cube
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.45s
     Running `target\debug\examples\cube.exe`
2024-11-29T21:38:03.582602Z  INFO bevy_diagnostic::system_information_diagnostics_plugin::internal: SystemInfo { os: "Windows 11 Education", kernel: "26100", cpu: "AMD Ryzen 5 3600X 6-Core Processor", core_count: "6", memory: "31.9 GiB" }
2024-11-29T21:38:03.973815Z  INFO bevy_render::renderer: AdapterInfo { name: "NVIDIA GeForce RTX 4080 SUPER", vendor: 4318, device: 9986, device_type: DiscreteGpu, driver: "NVIDIA", driver_info: "566.14", backend: Vulkan }
2024-11-29T21:38:04.799083Z  INFO bevy_winit::system: Creating new window "App" (0v1#4294967296)
2024-11-29T21:38:05.622205Z ERROR wgpu_core::device::global: Device::create_render_pipeline error: Error matching ShaderStages(FRAGMENT) shader requirements against the pipeline
2024-11-29T21:38:05.622506Z ERROR wgpu::backend::wgpu_core: Handling wgpu errors as fatal by default
thread 'Async Compute Task Pool (2)' panicked at C:\Users\linde\.cargo\registry\src\index.crates.io-6f17d22bba15001f\wgpu-23.0.1\src\backend\wgpu_core.rs:1102:18:
wgpu error: Validation Error

Caused by:
  In Device::create_render_pipeline, label = 'opaque_mesh_pipeline'
    Error matching ShaderStages(FRAGMENT) shader requirements against the pipeline
      Shader global ResourceBinding { group: 0, binding: 9 } is not available in the pipeline layout
        Storage class Storage { access: StorageAccess(LOAD) } doesn't match the shader Uniform


note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Encountered a panic in system `bevy_render::render_resource::pipeline_cache::PipelineCache::process_pipeline_queue_system`!
thread '<unnamed>' panicked at C:\Users\linde\.cargo\registry\src\index.crates.io-6f17d22bba15001f\bevy_render-0.15.0\src\render_resource\pipeline_cache.rs:546:28:
index out of bounds: the len is 0 but the index is 7
Encountered a panic in system `bevy_render::renderer::render_system`!
thread 'main' panicked at C:\Users\linde\.cargo\registry\src\index.crates.io-6f17d22bba15001f\wgpu-hal-23.0.1\src\vulkan\instance.rs:173:58:
Trying to destroy a SurfaceSemaphores that is still in use by a SurfaceTexture
```